### PR TITLE
Fix typos and need to fix Horovod conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ At this point it will ask for your password for anaconda cloud. You'll need to b
 
 ## Building a Python environment on Theta
 
-Simply run the script `conda_build_theta.sh <path/where/you/want/conda/installed>` and it will build an environment for machinne learning codes including a working version of Horovod and mpi4py. Activate the environment simply with `export PATH=<path/where/you/want/conda/installed>:$PATH`
+Simply run the script `conda_build_theta.sh <path/where/you/want/conda/installed>` and it will build an environment for machinne learning codes including a working version of Horovod and mpi4py. The target directory should not already exist; the Miniconda installer will fail even if the pre-existing target directory is empty. Activate the environment simply with `export PATH=<path/where/you/want/conda/installed>:$PATH`
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# theta_conda_channel
+# `theta_conda_channel`
 Files for building anaconda cloud packages for Theta.
 Misha Salim and Taylor Childers.
 
-# Building a package
+## Building a package
 
 Install a fresh miniconda version:
 ```
@@ -13,7 +13,7 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 
 Enter the base environment
 ```
-eval "$(mcondna3/bin/conda shell.bash hook)"
+eval "$(mconda3/bin/conda shell.bash hook)"
 ```
 
 You might need to install some things
@@ -33,7 +33,7 @@ anaconda upload --user argonne-lcf <path/to/tar.bz2>
 
 At this point it will ask for your password for anaconda cloud. You'll need to be associated with the organization to upload to it.
 
-# Building a Python environment on Theta
+## Building a Python environment on Theta
 
 Simply run the script `conda_build_theta.sh <path/where/you/want/conda/installed>` and it will build an environment for machinne learning codes including a working version of Horovod and mpi4py. Activate the environment simply with `export PATH=<path/where/you/want/conda/installed>:$PATH`
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 ./Miniconda3-latest-Linux-x86_64.sh -b -p $(pwd -LP)/mconda3
 ```
 
-Enter the base environment
+Enter the base environment:
 ```
 eval "$(mconda3/bin/conda shell.bash hook)"
 ```
 
-You might need to install some things
+You might need to install some things:
 ```
 conda install anaconda-client
 conda install conda-build
 ```
 
-Clone this repository and enter repo directory
+Clone this repository and enter repo directory:
 ```
 conda-build cython/
 ```
 
-The build will give you the path to the `*.tar.bz2` package file. Now you nneed to upload it
+The build will give you the path to the `*.tar.bz2` package file, e.g. `mconda/conda-bld/linux-64/cython-0.29.14-py37_0.tar.bz2`. Now you need to upload it:
 ```
 anaconda upload --user argonne-lcf <path/to/tar.bz2>
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ conda-build cython/
 
 The build will give you the path to the `*.tar.bz2` package file, e.g. `mconda/conda-bld/linux-64/cython-0.29.14-py37_0.tar.bz2`. Now you need to upload it:
 ```
-anaconda upload --user argonne-lcf <path/to/tar.bz2>
+anaconda upload --user alcf-theta <path/to/tar.bz2>
 ```
 
 At this point it will ask for your password for anaconda cloud. You'll need to be associated with the organization to upload to it.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 
 Enter the base environment:
 ```
-eval "$(mconda3/bin/conda shell.bash hook)"
+eval "$(mconda3/bin/conda shell.YOUR_SHELL_NAME hook)"
 ```
+where `YOUR_SHELL_NAME` is `bash`, `zsh`, `fish`, etc.
 
 You might need to install some things:
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ eval "$(mconda3/bin/conda shell.bash hook)"
 You might need to install some things
 ```
 conda install anaconda-client
+conda install conda-build
 ```
 
 Clone this repository and enter repo directory

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ eval "$(mconda3/bin/conda shell.bash hook)"
 You might need to install some things:
 ```
 conda install anaconda-client
-conda install conda-build
+conda install conda-build conda-verify
 ```
 
 Clone this repository and enter repo directory:

--- a/conda_build_theta.sh
+++ b/conda_build_theta.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 INSTALL_DIRECTORY" >&2
+  exit 1
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+wget -N https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 
 chmod a+x Miniconda3-latest-Linux-x86_64.sh
 
 ./Miniconda3-latest-Linux-x86_64.sh -b -p $1
 
 export PATH=$1/bin:$PATH
+conda_exe=$1/bin/conda
 
-conda install -y tensorflow=1.14 pytorch-cpu=1.2 mkl-dnn scipy pandas h5py virtualenv matplotlib scikit-learn 
-
-conda install -y -c alcf-theta mpi4py horovod
+${conda_exe} install -y tensorflow=1.14 pytorch-cpu=1.2 mkl-dnn scipy pandas h5py virtualenv matplotlib scikit-learn
+${conda_exe} install -y -c alcf-theta mpi4py horovod

--- a/conda_build_theta.sh
+++ b/conda_build_theta.sh
@@ -16,5 +16,5 @@ chmod a+x Miniconda3-latest-Linux-x86_64.sh
 export PATH=$1/bin:$PATH
 conda_exe=$1/bin/conda
 
-${conda_exe} install -y tensorflow=1.14 pytorch-cpu=1.2 mkl-dnn scipy pandas h5py virtualenv matplotlib scikit-learn
+${conda_exe} install -y tensorflow=1.14 pytorch mkl-dnn scipy pandas h5py virtualenv matplotlib scikit-learn
 ${conda_exe} install -y -c alcf-theta mpi4py horovod


### PR DESCRIPTION
The repo currently does not work due to a Horovod conflict with the installed `pytorch` versions:

```
Collecting package metadata (current_repodata.json): done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.
Solving environment: |
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed

UnsatisfiableError: The following specifications were found to be incompatible with each other:



Package _pytorch_select conflicts for:
_pytorch_select
pytorch -> _pytorch_select[version='0.1|0.2']
pytorch-cpu=1.2 -> pytorch=1.2.0 -> _pytorch_select==0.1
pytorch-cpu=1.2 -> _pytorch_select=0.1
horovod -> pytorch==1.3.1=cuda100py37h53c1284_0 -> _pytorch_select==0.2
Package pytorch conflicts for:
horovod -> pytorch[version='1.2|1.3.1',build='cuda100py37h53c1284_0|cuda100py37*|cuda100py37h938c94c_0']
pytorch
Package pyyaml conflicts for:
pytorch -> pyyaml
horovod -> pyyaml
Package psutil conflicts for:
horovod -> psutil
```

~This PR does not actually fix the conflict~, but I have rebuilt the 3x packages (with `pytorch-cpu=1.2`) and uploaded them to my personal Anaconda Cloud channel: https://anaconda.org/felker. I can upload to https://anaconda.org/alcf-theta if you add me as a member of the organization. 

Also, fixes some typos in the README.

**Update:** replacing `pytorch-cpu=1.2` with `pytorch` in the first set of packaged installations from the Anaconda Cloud default channel fixes the compatibility issue with the recent `horovod` package on `alcf-theta` channel which was built with CUDA/MKL compatibility. 

- [ ] Should `pytorch` be pinned to v1.2?